### PR TITLE
route-registrar: reflection method name for invoke

### DIFF
--- a/src/RouteRegistrar.php
+++ b/src/RouteRegistrar.php
@@ -127,7 +127,7 @@ class RouteRegistrar
 
                 $httpMethod = $attributeClass->method;
 
-                $action = $attributeClass->method === '__invoke'
+                $action = $method->getName() === '__invoke'
                     ? $class->getName()
                     : [$class->getName(), $method->getName()];
 


### PR DESCRIPTION
This corrects invokable controller detection by referencing the reflection method’s name instead of the attribute class’ method.